### PR TITLE
Add RansomLeak interactive training links alongside Kontra

### DIFF
--- a/api-security-study-plan.md
+++ b/api-security-study-plan.md
@@ -235,6 +235,7 @@ crAPI uses a microservices architecture and is composed of several services whic
 3. [API Security on Google Cloud's Apigee API Platform](https://www.coursera.org/learn/api-security-apigee-gcp)
 4. [API Fundamentals from Qualys for (free)](https://www.qualys.com/training/course/qualys-api-fundamentals/)
 5. [Introduction to the OWASP API Security Top 10 - Cybrary (free)](https://www.cybrary.it/course/securing-apis-fundamentals)
+6. [RansomLeak API Security Training](https://ransomleak.com/catalogue/api-security/) - Interactive browser-based labs
 
 ## Certifications
 1. [CSSLP](https://www.isc2.org/Certifications/CSSLP)

--- a/application-security-study-plan.md
+++ b/application-security-study-plan.md
@@ -145,6 +145,7 @@ Don't learn this from this page — go to the dedicated plans:
 3. [Application Security Guide - Udemy](https://www.udemy.com/course/application-security-the-complete-guide/)
 4. [Sec522: Application Security: Securing Web Apps, APIs, and Microservices from SANS](https://www.sans.org/cyber-security-courses/application-security-securing-web-apps-api-microservices/) Really nice one but costly.
 5. [Free OWASP Top 10 practice from Kontra Security](https://application.security/free/owasp-top-10)
+6. [RansomLeak Application Security Training](https://ransomleak.com/catalogue/application-security/) - Interactive browser-based labs
 
 ## Certifications
 1. [CSSLP: Certified Secure Software Lifecycle Professional](https://www.isc2.org/Certifications/CSSLP) Recommended

--- a/web-pentest-study-plan.md
+++ b/web-pentest-study-plan.md
@@ -127,6 +127,7 @@ Through 2025-2026 LLM-driven tooling became a normal part of the offensive toolk
 
 ### Week 9-16: Hands-on Practice
 1. [Kontra for OWASP Top 10 for Web](https://application.security/free/owasp-top-10)
+1a. [RansomLeak Application Security Training](https://ransomleak.com/catalogue/application-security/) - Interactive browser-based labs
 2. [hackthebox](https://www.hackthebox.com/)
 3. [tryhackme](https://tryhackme.com/)
 4. [OWASP WebGoat](https://owasp.org/www-project-webgoat/)


### PR DESCRIPTION
Adds RansomLeak's free interactive catalogues to three study plans, placing them right alongside the existing Kontra/application.security links:

**Application Security Study Plan:**
- [RansomLeak Application Security Training](https://ransomleak.com/catalogue/application-security/)

**API Security Study Plan:**
- [RansomLeak API Security Training](https://ransomleak.com/catalogue/api-security/)

**Web Pentesting Study Plan:**
- [RansomLeak Application Security Training](https://ransomleak.com/catalogue/application-security/)

These are browser-based hands-on training modules (no install/signup needed to browse) covering OWASP Top 10, API security, and secure development practices. They're built by the same team that created Kontra (the free OWASP training already in these study plans).

Disclosure: I work on RansomLeak. Formatting matches the surrounding entries and all URLs return 200.

https://claude.ai/code/session_01HGMArmtREp8pabSevihxCz