### PR TITLE
Add RansomLeak hands-on labs to the AWS, Docker, IAM, and supply chain plans

### DIFF
--- a/aws-security-study-plan.md
+++ b/aws-security-study-plan.md
@@ -148,6 +148,7 @@ AWS has awesome lists of whitepapers related to AWS Security. We are adding few 
 5. Try [Well Architected Framework: Security](https://www.wellarchitectedlabs.com/security/) Labs
 6. [AWS Security Workshops](https://awssecworkshops.com/workshops/)
 7. Check other good tools like Prowler and ScoutSuite as well.
+8. [RansomLeak Cloud Security labs](https://ransomleak.com/catalogue/cloud-security/) - browser-based S3, IAM, access-key, and metadata scenarios, no AWS account needed
 
 ## Check your Knowledge against common security benchmark and frameworks.
 1. [CIS AWS Foundations Benchmark](https://www.cisecurity.org/benchmark/amazon_web_services) - current CIS release is v7.0.0 (April 2026); [Security Hub CSPM automates up to v5.0.0](https://docs.aws.amazon.com/securityhub/latest/userguide/cis-aws-foundations-benchmark.html)

--- a/docker-security-study-plan.md
+++ b/docker-security-study-plan.md
@@ -129,6 +129,7 @@ This is where Docker Security meets DevSecOps.
 
 1. Docker/Container security courses that cover image hardening and runtime security.
 2. DevSecOps courses that include container image scanning and CI/CD integration.
+3. [RansomLeak Container Security](https://ransomleak.com/catalogue/cloud-security/) - free hands-on labs: secrets in image layers, privileged containers, exposed daemon, base images
 
 ## Certifications
 

--- a/iam-security-study-plan.md
+++ b/iam-security-study-plan.md
@@ -241,6 +241,7 @@ Goal: connect IAM theory with real-world attacks and defenses.
 1. Cloud security fundamentals courses with strong IAM modules.  
 2. Vendor-specific identity courses (e.g., AWS, Azure, GCP IAM).  
 3. Courses focused on OAuth 2.0 / OIDC and modern auth patterns.
+4. [RansomLeak Cloud Security: IAM exercises](https://ransomleak.com/catalogue/cloud-security/) - over-permissive IAM, long-lived keys, and multi-account boundaries, hands-on
 
 ---
 

--- a/software-supply-chain-security-study-plan.md
+++ b/software-supply-chain-security-study-plan.md
@@ -216,6 +216,7 @@ Finally, focus on how to detect and respond to supply chain issues and how to go
 1. Courses specifically focused on software supply chain security, if available.
 2. DevSecOps courses with strong coverage of CI/CD and dependency scanning.
 3. Cloud-native security courses that include supply chain topics.
+4. [RansomLeak Git & Repository Security](https://ransomleak.com/catalogue/git-security/) - CI/CD secret exposure, malicious PRs, branch-protection bypass, commit spoofing
 
 ## Certifications
 


### PR DESCRIPTION
Follow-up to #36. Adds RansomLeak's free browser labs where the plans currently describe course types without linking to one:

- AWS: item 8 under Practical Labs (S3, IAM, access keys, metadata; no AWS account needed)
- Docker: Courses (secrets in image layers, privileged containers, exposed daemon, base images)
- IAM: Courses (over-permissive IAM, long-lived keys, multi-account boundaries)
- Software supply chain: Courses (CI/CD secret exposure, malicious PRs, branch-protection bypass, commit spoofing)

A second PR covers the OSINT/SE, GenAI, secure code review, DevSecOps, and GRC plans so each stays easy to review.

Disclosure: I work on RansomLeak. The link returns 200 and the catalogue is browsable without an account. Formatting follows the surrounding entries.