### PR TITLE
Add RansomLeak exercises to the OSINT/SE, GenAI, code review, DevSecOps, and GRC plans

### DIFF
--- a/devsecops-study-plan.md
+++ b/devsecops-study-plan.md
@@ -192,6 +192,7 @@ DevSecOps is as much about **people and feedback** as it is about tools.
 1. DevSecOps-focused courses that cover CI/CD, automation, and security tooling.
 2. Cloud-native security courses that include pipeline and platform topics.
 3. Container and Kubernetes security courses that show how to integrate checks into pipelines.
+4. [RansomLeak developer track](https://ransomleak.com/catalogue/git-security/) - Git, CI/CD, container, and cloud security labs in the browser
 
 ## Certifications
 

--- a/genai-security-study-plan.md
+++ b/genai-security-study-plan.md
@@ -731,6 +731,7 @@ This section flips the lens: instead of securing GenAI systems, it covers using 
    - [Coursera: Generative AI for Cybersecurity Professionals (IBM)](https://www.coursera.org/specializations/generative-ai-for-cybersecurity-professionals)
    - [Coursera: AI for Cybersecurity Specialization (Johns Hopkins)](https://www.coursera.org/specializations/ai-for-cybersecurity)
    - [AttackIQ: Foundations of AI Security](https://www.academy.attackiq.com/courses/foundations-of-ai-security)
+   - [RansomLeak: OWASP LLM, Agentic, and MCP Top 10 exercises](https://ransomleak.com/catalogue/ai-security/)
 
 2. **Security Guides & Checklists**
    - [OWASP Top 10 for LLM Applications 2026](https://genai.owasp.org/resource/owasp-genai-llm-top-10-2026/) *(current)*

--- a/grc-study-plan.md
+++ b/grc-study-plan.md
@@ -345,6 +345,7 @@ Measuring the effectiveness of a GRC program involves establishing metrics that 
 - **LinkedIn Learning:** Offers courses on risk management, governance, and compliance.
 - **Pluralsight:** Provides courses on GRC concepts and frameworks.
 - **Coursera/Udemy/Udacity/EdX:** Look for courses on GRC fundamentals, risk management, and compliance.
+- **RansomLeak:** [Interactive compliance training](https://ransomleak.com/catalogue/privacy-compliance/) mapped to GDPR, EU AI Act, NIS2, ISO 27001, HIPAA, and SOC 2 awareness clauses.
 
 ### Communities
 - **ISACA:** Offers resources, forums, and events for GRC professionals.

--- a/osint-social-engineering-study-plan.md
+++ b/osint-social-engineering-study-plan.md
@@ -157,6 +157,7 @@ Goal: use OSINT and SE knowledge to improve defenses.
 1. Intro OSINT courses that emphasize legality and ethics.  
 2. Social engineering awareness and simulation courses.  
 3. Red team or phishing simulation courses if relevant to your job.
+4. [RansomLeak Social Engineering simulations](https://ransomleak.com/catalogue/security-awareness/) - phishing, vishing, smishing, deepfake, and pretexting exercises, free for individuals
 
 ---
 

--- a/secure-code-review-study-plan.md
+++ b/secure-code-review-study-plan.md
@@ -133,3 +133,4 @@ Enhancing manual review with tools.
 ### Practice
 - [Secure Code Warrior](https://www.securecodewarrior.com/) (Free trial/community)
 - [SonarQube Rules documentation](https://docs.sonarsource.com/sonarqube-server/quality-standards-administration/managing-rules/rules) (Learn by seeing bad vs good code – the old `rules.sonarsource.com` explorer has been retired; browse the rules catalog from a SonarQube Server/Cloud instance)
+- [RansomLeak Application Security](https://ransomleak.com/catalogue/application-security/) (Free, exploit-then-fix OWASP Top 10 labs)


### PR DESCRIPTION
Companion to the infrastructure PR. Adds RansomLeak's free browser exercises to sections that list course types without a concrete link:

- OSINT and social engineering: Courses (phishing, vishing, smishing, deepfake, pretexting simulations)
- GenAI security: Additional Resources > Courses (OWASP LLM, Agentic, and MCP Top 10 exercises)
- Secure code review: Practice, next to Secure Code Warrior (exploit-then-fix OWASP Top 10 labs)
- DevSecOps: Courses (Git, CI/CD, container, and cloud labs)
- GRC: Online Platforms (compliance training mapped to GDPR, EU AI Act, NIS2, ISO 27001, HIPAA, SOC 2)

Disclosure: I work on RansomLeak. The link returns 200 and the catalogue is browsable without an account. Formatting follows the surrounding entries.